### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,7 +38,7 @@
       {
         "slug": "armstrong-numbers",
         "name": "Armstrong Numbers",
-        "uuid": "a4bdbdfd-1db1-425c-a243-dd032dc7b93a",
+        "uuid": "b115501d-b51a-4765-9bc3-4b746260fe80",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
@@ -49,7 +49,7 @@
       {
         "slug": "hello-world",
         "name": "Hello World",
-        "uuid": "1378910d-9bec-4217-bd40-07a8967fa3ad",
+        "uuid": "90f0f5a4-494b-49a8-8dfd-6faac67bdf7f",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
@@ -58,7 +58,7 @@
       {
         "slug": "reverse-string",
         "name": "Reverse String",
-        "uuid": "a8957cc5-d99e-4a31-9d49-4653226fd50b",
+        "uuid": "0cd68fef-84f9-412f-ad31-f628ab4b4a6f",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
@@ -67,7 +67,7 @@
       {
         "slug": "two-fer",
         "name": "Two Fer",
-        "uuid": "91a1f32c-0dac-4c65-8a13-49da90d21520",
+        "uuid": "076873ed-e43b-4a5c-ba94-9d8b2e299413",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
@@ -76,7 +76,7 @@
       {
         "slug": "accumulate",
         "name": "Accumulate",
-        "uuid": "73cdbbd8-04a6-42ba-aeea-1f1c8d53af70",
+        "uuid": "154c6293-7ade-43c8-ae56-7c4f6849a9a0",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -85,7 +85,7 @@
       {
         "slug": "acronym",
         "name": "Acronym",
-        "uuid": "e14a4261-c84f-417e-841e-29ff6f1f533d",
+        "uuid": "3468dee8-d18b-4a0e-b502-c8efd481a6f9",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -94,7 +94,7 @@
       {
         "slug": "all-your-base",
         "name": "All Your Base",
-        "uuid": "b55eefa5-dce6-46fb-8c0e-4c476cc871ce",
+        "uuid": "6f638400-57bf-4130-97a1-9f01a0165374",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -105,7 +105,7 @@
       {
         "slug": "anagram",
         "name": "Anagram",
-        "uuid": "04ac2bd0-504c-4faa-912e-d2111b46123c",
+        "uuid": "70b563b0-d1ce-49cf-871a-96e0f8d420b1",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -114,7 +114,7 @@
       {
         "slug": "bob",
         "name": "Bob",
-        "uuid": "d3bcad28-db03-4f6c-a85d-9f2d01331e88",
+        "uuid": "5c0bdaf9-7ee6-4d7c-94d6-d1d7cb1591a1",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -123,7 +123,7 @@
       {
         "slug": "collatz-conjecture",
         "name": "Collatz Conjecture",
-        "uuid": "c14ef548-c5f6-43a9-84e2-c7248705fc8e",
+        "uuid": "52fa9aa7-7f8b-4045-bd41-9e558e00c5a4",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -134,7 +134,7 @@
       {
         "slug": "complex-numbers",
         "name": "Complex Numbers",
-        "uuid": "95580d10-92db-4809-b5e7-4085319d19e9",
+        "uuid": "e9a69b69-6c93-4971-a27c-e5720cd265f4",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -145,7 +145,7 @@
       {
         "slug": "etl",
         "name": "Etl",
-        "uuid": "c51658c1-7cdb-4a45-8d4d-2a370b655362",
+        "uuid": "49a930cc-9d7c-4c89-ab2b-cbcf348256f2",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -154,7 +154,7 @@
       {
         "slug": "hamming",
         "name": "Hamming",
-        "uuid": "60004bf0-e551-4bfc-bda9-49c5611811c4",
+        "uuid": "12f806f2-4825-4a5c-9f7e-8e4322989bc6",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -163,7 +163,7 @@
       {
         "slug": "nth-prime",
         "name": "Nth Prime",
-        "uuid": "d380de85-4d35-4342-9b88-7402deea2869",
+        "uuid": "9737c59a-d7f5-4a8e-a27f-41f79a88e085",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -174,7 +174,7 @@
       {
         "slug": "nucleotide-count",
         "name": "Nucleotide Count",
-        "uuid": "66d97ae9-36ac-47c6-8b9f-e77ce498fc70",
+        "uuid": "da480483-5bfa-468e-90c4-72e2f9d5c900",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -183,7 +183,7 @@
       {
         "slug": "pangram",
         "name": "Pangram",
-        "uuid": "398f65f2-2324-4b08-945d-a9fbd62d1a41",
+        "uuid": "37ce9067-63d0-4a5c-938a-fe03a82f55b6",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -192,7 +192,7 @@
       {
         "slug": "pig-latin",
         "name": "Pig Latin",
-        "uuid": "6768b55e-bab3-4e55-ac71-ddda0bd16298",
+        "uuid": "99c994d3-4376-42cb-b1cc-a913145eb250",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -201,7 +201,7 @@
       {
         "slug": "protein-translation",
         "name": "Protein Translation",
-        "uuid": "c4b7120c-a7c5-4a39-a08e-8d4fb9861a27",
+        "uuid": "e7406898-a5ce-47f8-ac1e-c1e0dd7b194e",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -213,7 +213,7 @@
       {
         "slug": "raindrops",
         "name": "Raindrops",
-        "uuid": "c1113f92-df4d-4d04-865f-20b8b2c56205",
+        "uuid": "7f26084e-d806-40dd-9c97-c29f69838a4b",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -222,7 +222,7 @@
       {
         "slug": "rna-transcription",
         "name": "Rna Transcription",
-        "uuid": "c2100dff-4d18-4fcb-9035-6c57eddd6d37",
+        "uuid": "09a7539b-85a3-42e5-9966-923482c3c927",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -231,7 +231,7 @@
       {
         "slug": "robot-name",
         "name": "Robot Name",
-        "uuid": "3ce7ad7d-61ef-4a71-b87a-8c1b45c758b6",
+        "uuid": "b3b4a2b1-5616-49e4-bb25-4d74e0287ae5",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -240,7 +240,7 @@
       {
         "slug": "roman-numerals",
         "name": "Roman Numerals",
-        "uuid": "04d0369f-b0e5-4c00-a0f7-1b86eefba484",
+        "uuid": "8c613b74-d29c-49d5-9eb2-b23ced58fbd8",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -249,7 +249,7 @@
       {
         "slug": "rotational-cipher",
         "name": "Rotational Cipher",
-        "uuid": "622823dc-ee47-42a0-acc6-190de4541625",
+        "uuid": "747efbe6-7e39-4c47-b75b-395ee1a37303",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -258,7 +258,7 @@
       {
         "slug": "run-length-encoding",
         "name": "Run Length Encoding",
-        "uuid": "04a6c1d6-6cce-4c87-a34b-23fdd9baf70d",
+        "uuid": "6fa8645a-47f5-4eab-bb48-4ecf16869c08",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -267,7 +267,7 @@
       {
         "slug": "scrabble-score",
         "name": "Scrabble Score",
-        "uuid": "01afac67-ff81-432e-b2a0-63f4540f2eb5",
+        "uuid": "3b09afea-37ea-4933-962b-9a2ba4492e68",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -276,7 +276,7 @@
       {
         "slug": "secret-handshake",
         "name": "Secret Handshake",
-        "uuid": "2cc37c2a-7e6c-49ba-8b30-2ff8c9d818c2",
+        "uuid": "99264d8d-1fa4-4467-bb89-9ae75e8b3348",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -285,7 +285,7 @@
       {
         "slug": "series",
         "name": "Series",
-        "uuid": "c34af548-c5f6-43a9-84e2-c4166605fc8e",
+        "uuid": "81781dbe-0a35-4582-953e-c34830ce4c50",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -294,7 +294,7 @@
       {
         "slug": "space-age",
         "name": "Space Age",
-        "uuid": "735e991b-f736-4ca2-80db-f94e20aa2319",
+        "uuid": "3f5659ee-3a8b-4b1f-8f8b-649e56036c02",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -303,7 +303,7 @@
       {
         "slug": "strain",
         "name": "Strain",
-        "uuid": "ad08dcef-14f7-406d-b3a5-4b5aad37ebf1",
+        "uuid": "efd34181-c342-4d61-8bdc-3968ca2128cc",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -312,7 +312,7 @@
       {
         "slug": "sublist",
         "name": "Sublist",
-        "uuid": "dabe93c3-038c-4c6f-8a2e-f50acf130b8f",
+        "uuid": "a4c079d9-a679-4d31-b693-f5ad7ab8bac9",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -321,7 +321,7 @@
       {
         "slug": "sum-of-multiples",
         "name": "Sum Of Multiples",
-        "uuid": "a7e1d0a1-feb5-4a55-93c7-e7f81a39238c",
+        "uuid": "821e618d-6941-4e80-b8ce-dff5b3f7d259",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -332,7 +332,7 @@
       {
         "slug": "triangle",
         "name": "Triangle",
-        "uuid": "74f7eacd-d3de-4467-85b2-8590ba1f28ce",
+        "uuid": "44e441a6-c486-451a-a727-010ee273d02b",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -341,7 +341,7 @@
       {
         "slug": "word-count",
         "name": "Word Count",
-        "uuid": "3ab74232-11f5-4efd-82ac-e7c4129c7ff4",
+        "uuid": "c47f5ba3-bfcd-4892-972e-335172291e44",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -350,7 +350,7 @@
       {
         "slug": "atbash-cipher",
         "name": "Atbash Cipher",
-        "uuid": "47266422-622e-4e20-b597-e85ab7bd3046",
+        "uuid": "7fc4f956-e534-4c31-ba14-29b545a4ac47",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -359,7 +359,7 @@
       {
         "slug": "beer-song",
         "name": "Beer Song",
-        "uuid": "c14ef548-c5f6-43a9-84e2-c7238705fc8e",
+        "uuid": "88e280f6-5c30-47ca-a143-13aaf171c671",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -368,7 +368,7 @@
       {
         "slug": "binary",
         "name": "Binary",
-        "uuid": "4c59731d-165a-43e1-9917-16131dadbbac",
+        "uuid": "a8fdd7c5-f0c7-40e1-bc19-bb8b8beb806c",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -379,7 +379,7 @@
       {
         "slug": "binary-search",
         "name": "Binary Search",
-        "uuid": "36f47cc4-0c5e-4edc-b109-c9e007b7b1f8",
+        "uuid": "5dcefb4b-0d76-47e4-9d09-73d77f95574d",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -388,7 +388,7 @@
       {
         "slug": "binary-search-tree",
         "name": "Binary Search Tree",
-        "uuid": "62f3cbcb-2503-472f-9544-50e05e368949",
+        "uuid": "c1a028bb-54b9-434d-9a71-3ca20c16aaf1",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -397,7 +397,7 @@
       {
         "slug": "change",
         "name": "Change",
-        "uuid": "6fd886e5-94b0-4938-9f48-f4c6850027a0",
+        "uuid": "68a2d20c-0b90-4ab8-849f-a31f5a053f93",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -406,7 +406,7 @@
       {
         "slug": "flatten-array",
         "name": "Flatten Array",
-        "uuid": "11450b65-628d-4890-a668-7031de985f5c",
+        "uuid": "b6328a94-326f-44d6-bedc-0187c8d65ea1",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -415,7 +415,7 @@
       {
         "slug": "gigasecond",
         "name": "Gigasecond",
-        "uuid": "23498ff3-310e-41b0-b15e-52fec2f2bfcb",
+        "uuid": "cb73a4f9-dbf0-4d32-a6df-83c574c8aad4",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -424,7 +424,7 @@
       {
         "slug": "grade-school",
         "name": "Grade School",
-        "uuid": "f4cf3676-4399-4d1c-b21f-8e735c7af8cc",
+        "uuid": "ddf9172d-e7aa-462a-9a2c-3c57b2b7b990",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -433,7 +433,7 @@
       {
         "slug": "grains",
         "name": "Grains",
-        "uuid": "27b44b76-5e4f-4711-bce0-869e372636dd",
+        "uuid": "52c3b29a-1e18-4be0-80ca-6dbc4d1c72bf",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -442,7 +442,7 @@
       {
         "slug": "hexadecimal",
         "name": "Hexadecimal",
-        "uuid": "8ede90b5-d1ad-41c3-8474-2ffaea39e7e4",
+        "uuid": "efeb8f32-56d6-4f63-9b5e-aa7c35ab95e9",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -453,7 +453,7 @@
       {
         "slug": "isbn-verifier",
         "name": "Isbn Verifier",
-        "uuid": "e6411d18-d9b9-48fa-8ee6-0df8c13d3dee",
+        "uuid": "8f3e7ab3-cb6f-4ca9-8738-686f9d1d901b",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -462,7 +462,7 @@
       {
         "slug": "isogram",
         "name": "Isogram",
-        "uuid": "1fc5c2e9-2851-4735-8fde-612a8c054a5a",
+        "uuid": "8cda1d7c-e68a-4ea8-a26d-92e5bb1adda2",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -471,7 +471,7 @@
       {
         "slug": "kindergarten-garden",
         "name": "Kindergarten Garden",
-        "uuid": "5288c0fb-a90d-4f71-b525-e9a7b687aaf2",
+        "uuid": "c16d5b52-5310-4c77-96ce-52e860372a02",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -480,7 +480,7 @@
       {
         "slug": "leap",
         "name": "Leap",
-        "uuid": "0cde8a62-412a-45cc-b16e-4b31057cab74",
+        "uuid": "32a8c12c-8f1c-4a1e-91e8-ebd38f913819",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -489,7 +489,7 @@
       {
         "slug": "pascals-triangle",
         "name": "Pascals Triangle",
-        "uuid": "9c8c4689-4990-4266-a02e-2dcb9fa32402",
+        "uuid": "b11e1f99-666f-451b-b839-9389201ee9a0",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -500,7 +500,7 @@
       {
         "slug": "perfect-numbers",
         "name": "Perfect Numbers",
-        "uuid": "097edd69-91b5-4a71-b197-a9c14b61c4ce",
+        "uuid": "08a30e81-0762-43f9-8571-a5a8ce82f826",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -511,7 +511,7 @@
       {
         "slug": "phone-number",
         "name": "Phone Number",
-        "uuid": "84ce66e5-6091-4078-9921-c0b8ccabc86f",
+        "uuid": "4702eb7a-ebf2-4cfa-aa46-e778c45f3d25",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -520,7 +520,7 @@
       {
         "slug": "prime-factors",
         "name": "Prime Factors",
-        "uuid": "068a0997-d333-48cb-a82a-c5082e85115d",
+        "uuid": "adf52092-bbb4-4900-9365-d4e35fabaa7e",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -531,7 +531,7 @@
       {
         "slug": "proverb",
         "name": "Proverb",
-        "uuid": "c8ba6ce5-9a7e-4c1c-8044-bb18a0d6ad39",
+        "uuid": "689279e7-074f-4bb3-98a9-410009bcaba9",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -540,7 +540,7 @@
       {
         "slug": "say",
         "name": "Say",
-        "uuid": "31aa2618-b971-44ff-9799-761fdec53b87",
+        "uuid": "e2e6caae-aed2-410a-b07e-59d2df9a40ff",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -549,7 +549,7 @@
       {
         "slug": "trinary",
         "name": "Trinary",
-        "uuid": "d32f41d4-e1b1-4daf-8ddc-a2ab9ee07c98",
+        "uuid": "54ba5e35-a35f-4a32-9009-5435d16f6fff",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -560,7 +560,7 @@
       {
         "slug": "allergies",
         "name": "Allergies",
-        "uuid": "810803c7-4480-4e11-b848-d56477ba9d08",
+        "uuid": "4807b3a1-c4ae-4bd0-acd5-d10436d688da",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -569,7 +569,7 @@
       {
         "slug": "crypto-square",
         "name": "Crypto Square",
-        "uuid": "8b90d4c5-0d53-4664-afba-c4ed1c865e77",
+        "uuid": "f542d6ed-d5f2-44ed-a234-682766400cdf",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -578,7 +578,7 @@
       {
         "slug": "difference-of-squares",
         "name": "Difference Of Squares",
-        "uuid": "254199d8-8add-470f-a8fc-8ec9ffc54dd1",
+        "uuid": "78cae41d-7831-4298-b96f-983d44eadbb5",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -589,7 +589,7 @@
       {
         "slug": "dominoes",
         "name": "Dominoes",
-        "uuid": "db6162c0-adff-401e-9dd6-a0322ca10dcf",
+        "uuid": "91fc0f40-83d5-4d86-a52a-0b0327694097",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -598,7 +598,7 @@
       {
         "slug": "largest-series-product",
         "name": "Largest Series Product",
-        "uuid": "eec9ea9a-fa32-4ea2-831e-0caccbca208b",
+        "uuid": "4c71c594-2621-4d83-8cfc-747d957c8b97",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -609,7 +609,7 @@
       {
         "slug": "meetup",
         "name": "Meetup",
-        "uuid": "1657cd1a-f3d8-475f-824f-31ba4d8e229a",
+        "uuid": "14ba002c-425e-4e64-8124-869d71c40093",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -618,7 +618,7 @@
       {
         "slug": "octal",
         "name": "Octal",
-        "uuid": "db1a86fb-2f04-4afe-9e45-00b539c86b63",
+        "uuid": "1614dce1-02d6-49ab-8b2a-53d9534a4187",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -640,7 +640,7 @@
       {
         "slug": "clock",
         "name": "Clock",
-        "uuid": "8e722baf-bbf9-445f-9adb-b21db88b5132",
+        "uuid": "13503c5b-d183-482e-acfc-c2ca8997716f",
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
@@ -649,7 +649,7 @@
       {
         "slug": "diamond",
         "name": "Diamond",
-        "uuid": "f3971f71-08c9-4e36-a69e-5bd7fe070b07",
+        "uuid": "859dd61c-2c79-47ed-b4e3-c76e52e2de42",
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
@@ -658,7 +658,7 @@
       {
         "slug": "luhn",
         "name": "Luhn",
-        "uuid": "5f62a862-f65e-4af0-a15d-5aa1fdb4f970",
+        "uuid": "508f71a9-b16f-4911-a786-7dbca631d629",
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
@@ -667,7 +667,7 @@
       {
         "slug": "sieve",
         "name": "Sieve",
-        "uuid": "910adfb9-be3e-45ef-af4c-facba7825cfd",
+        "uuid": "be3d9c81-a3e3-439c-9db4-77493f7f1195",
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
@@ -678,7 +678,7 @@
       {
         "slug": "robot-simulator",
         "name": "Robot Simulator",
-        "uuid": "e4f94fe1-7258-4e55-94c8-756a8080f898",
+        "uuid": "6156a4bd-0981-4cc2-973e-7cc6acfe515c",
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
@@ -687,7 +687,7 @@
       {
         "slug": "wordy",
         "name": "Wordy",
-        "uuid": "4a2033a7-5579-49ac-94d7-8693cee45381",
+        "uuid": "63c93bcf-9b85-46f7-9a4f-3eec0a5e33e7",
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
@@ -696,7 +696,7 @@
       {
         "slug": "bank-account",
         "name": "Bank Account",
-        "uuid": "e6848f52-a6b5-4669-9b50-beedfd3ebe2f",
+        "uuid": "b165f901-911d-4d90-a1d4-8079274d1ea5",
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
@@ -705,7 +705,7 @@
       {
         "slug": "matching-brackets",
         "name": "Matching Brackets",
-        "uuid": "c8ebc25b-17b9-44a9-8cbe-df2c2eb6e2d6",
+        "uuid": "633c2cc4-56ba-48b6-a2c7-42872841f248",
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
@@ -714,7 +714,7 @@
       {
         "slug": "minesweeper",
         "name": "Minesweeper",
-        "uuid": "2d35d9b3-5cff-4e68-a861-1461b32e22ba",
+        "uuid": "88b0eaaf-7623-4bf2-a91f-2980ff2a11b8",
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
@@ -723,7 +723,7 @@
       {
         "slug": "poker",
         "name": "Poker",
-        "uuid": "7df7ff1c-74ab-4f4e-aaf0-257b6e1cbc18",
+        "uuid": "1d429d3e-9989-4e7f-9bb5-f144b3f0d803",
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
@@ -732,7 +732,7 @@
       {
         "slug": "queen-attack",
         "name": "Queen Attack",
-        "uuid": "0bc807ef-60b8-49d9-9428-0060bc5517a9",
+        "uuid": "3edbd56d-5328-4a5a-9f78-43082f7b4a79",
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
@@ -741,7 +741,7 @@
       {
         "slug": "go-counting",
         "name": "Go Counting",
-        "uuid": "987438e8-1db3-447a-a243-e67c7591709d",
+        "uuid": "e13a765e-24d1-469a-98bf-f98c51630df9",
         "practices": [],
         "prerequisites": [],
         "difficulty": 9,
@@ -750,7 +750,7 @@
       {
         "slug": "pov",
         "name": "Pov",
-        "uuid": "ee9b837b-ea2f-4c77-9a3d-3d0007b9ae88",
+        "uuid": "5cd961f1-1e8e-4378-8544-0fd42ab7de87",
         "practices": [],
         "prerequisites": [],
         "difficulty": 10,

--- a/config.json
+++ b/config.json
@@ -629,7 +629,7 @@
       {
         "slug": "spiral-matrix",
         "name": "Spiral Matrix",
-        "uuid": "d42g42d7-21b1-4daf-8ddc-a2ab9ee07c98",
+        "uuid": "119143fe-e04d-4464-880a-fd76b05454fa",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
