### PR TITLE
🤖 Remove obsolete `maintainers.json` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-
 # Changes to `fetch-configlet` should be made in the `exercism/configlet` repo
 bin/fetch-configlet     @exercism/maintainers-admin
 

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,4 +1,0 @@
-{
-  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md",
-  "maintainers": []
-}


### PR DESCRIPTION
The `maintainers.json` file has been deprecated and no longer has any use.
This PR removes this `maintainers.json` file.

## Tracking
https://github.com/exercism/exercism/issues/6094