### PR TITLE
Use Clojure online editor settings (#29)

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,8 +13,8 @@
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4,
-    "highlightjs_language": "text"
+    "indent_size": 2,
+    "highlightjs_language": "clojure"
   },
   "files": {
     "solution": [


### PR DESCRIPTION
We use the Clojure highlightjs syntax highlighting.

Two spaces are used for indenting.

Closes #29
