### PR TITLE
Declare concept exercises in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,7 +31,88 @@
     ]
   },
   "exercises": {
-    "concept": [],
+    "concept": [
+      {
+        "slug": "lucians-luscious-lasagna",
+        "name": "Lucian's Luscious Lasagna",
+        "uuid": "7fbd4b71-f0ca-4964-ace6-8dd55eef271f",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "tracks-on-tracks-on-tracks",
+        "name": "Tracks on Tracks on Tracks",
+        "uuid": "6f9e1426-b10a-4c24-bc5b-49ade665b1d3",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "bird-watcher",
+        "name": "Bird Watcher",
+        "uuid": "7999d43e-6a37-4aa5-9bdc-715464a39a77",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "cars-assemble",
+        "name": "Cars, Assemble!",
+        "uuid": "59ab5e80-ce29-4805-b6c6-d05285dc3937",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "interest-is-interesting",
+        "name": "Interest is Interesting",
+        "uuid": "97c99ea3-2eb6-492d-86b7-7237a74fef84",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "annalyns-infiltration",
+        "name": "Annalyn's Infiltration",
+        "uuid": "9dd08d71-7e89-4e10-b873-57cfa5b6485c",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "log-levels",
+        "name": "Log Levels",
+        "uuid": "b957b070-2982-4c62-86ff-af94a0821159",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "elyses-destructured-enchantments",
+        "name": "Elyses Destructured Enchantments",
+        "uuid": "8ab7cdae-1e76-44e0-8ce9-53ff7ddad6a4",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "international-calling-connoisseur",
+        "name": "International Calling Connoisseur",
+        "uuid": "33692705-1d8e-47a5-af7d-37c8ea95b6c1",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      },
+      {
+        "slug": "squeaky-clean",
+        "name": "Squeaky Clean",
+        "uuid": "b60429d0-d945-4bd5-a3aa-360020441d0c",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "wip"
+      }
+    ],
     "practice": [
       {
         "slug": "armstrong-numbers",


### PR DESCRIPTION
We address lint failures (#13) by declaring the concept exercises.

Note we haven't declared the concepts themselves, as the required `concepts/` directories do not exist.
